### PR TITLE
fix: Remove unnecessary scrollbar from output area in main GUI

### DIFF
--- a/main_gui.cpp
+++ b/main_gui.cpp
@@ -79,7 +79,7 @@ int main(int, char**) {
         ImGui::Begin("Main", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus);
 
         // --- Output Area ---
-        ImGui::BeginChild("Output", ImVec2(0, output_height), true, ImGuiWindowFlags_HorizontalScrollbar);
+        ImGui::BeginChild("Output", ImVec2(0, output_height), true);
         // Use the local output_history vector updated by processDisplayQueue
         for (const auto& line : output_history) {
             // Use TextWrapped for better readability of long lines


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the output area to use default scrollbar behavior, removing the forced horizontal scrollbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->