### PR TITLE
Fix #16: Enable text selection/copying in GUI dialogue

### DIFF
--- a/main_gui.cpp
+++ b/main_gui.cpp
@@ -124,8 +124,12 @@ int main(int, char**) {
                     break;
             }
 
-            // Use TextWrapped for better readability of long lines
-            ImGui::TextWrapped("%s", display_text.c_str());
+            // Use Selectable to enable text selection/copying
+            // Use GetContentRegionAvail().x for width to wrap text within the child window
+            if (ImGui::Selectable(display_text.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick, ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
+                // On click, copy text to clipboard
+                ImGui::SetClipboardText(display_text.c_str());
+            }
 
             // Pop color if one was pushed
             if (color_pushed) {


### PR DESCRIPTION
Implements text selection and copying in the GUI dialogue history by using `ImGui::Selectable`. Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Messages in the output area can now be selected and copied by clicking on them.

- **Enhancements**
  - Improved message display by allowing text selection and copying, making it easier to interact with output messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->