### PR TITLE
Fix: Remove Ctrl-D message in GUI mode (closes #17)

### DIFF
--- a/chat_client.cpp
+++ b/chat_client.cpp
@@ -218,7 +218,12 @@ std::string ChatClient::executeAndPrepareToolResult(
 // Accept the stop_token for cooperative cancellation
 void ChatClient::run(std::stop_token st) {
     db.cleanupOrphanedToolMessages();
-    ui.displayOutput("Chatting with " + this->model_name + " - Type your message (Ctrl+D to exit)\n"); // Use UI
+    std::string initial_message = "Chatting with " + this->model_name + " - Type your message";
+    if (!ui.isGuiMode()) {
+        initial_message += " (Ctrl+D to exit)";
+    }
+    initial_message += "\n";
+    ui.displayOutput(initial_message); // Use UI, message adapted for CLI/GUI
     while (true) {
         // Check for stop request at the beginning of each loop iteration
         if (st.stop_requested()) {

--- a/cli_interface.cpp
+++ b/cli_interface.cpp
@@ -70,3 +70,8 @@ void CliInterface::displayStatus(const std::string& status) {
     }                                                                                                                                                                    
     std::cout.flush(); // Ensure status is displayed immediately                                                                                                         
 }       
+
+// Implementation for isGuiMode - CLI is never GUI mode.
+bool CliInterface::isGuiMode() const {
+    return false;
+}

--- a/cli_interface.h
+++ b/cli_interface.h
@@ -17,4 +17,5 @@ public:
     virtual void displayStatus(const std::string& status) override;                                                                                                      
     virtual void initialize() override;                                                                                                                                  
     virtual void shutdown() override;                                                                                                                                    
+virtual bool isGuiMode() const override;
 };          

--- a/gui_interface/gui_interface.cpp
+++ b/gui_interface/gui_interface.cpp
@@ -365,3 +365,8 @@ ImVec2 GuiInterface::getAndClearScrollOffsets() {
     accumulated_scroll_y = 0.0f;
     return offsets;
 }
+
+// Implementation for isGuiMode - GUI is always GUI mode.
+bool GuiInterface::isGuiMode() const {
+    return true;
+}

--- a/gui_interface/gui_interface.h
+++ b/gui_interface/gui_interface.h
@@ -46,6 +46,7 @@ public:
     virtual void displayStatus(const std::string& status) override;
     virtual void initialize() override;
     virtual void shutdown() override;
+virtual bool isGuiMode() const override;
 
     // Public method to get the window handle (needed by main_gui.cpp)
     GLFWwindow* getWindow() const;

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -13,6 +13,7 @@ This file tracks the project's progress using a task list format.
 *   [2025-05-04 02:08:45] - Completed planning phase for GitHub issue #15 (Touch scrolling GUI bug). Plan added to issue description on GitHub.
 
 ## Current Tasks
+*   [2025-05-05 15:43:10] - Started work on issue #17 (GUI: Remove or adapt 'Ctrl-D to exit' message) on branch fix/issue-17-gui-ctrl-d-message.
 
 *   [COMPLETED - 2025-05-04 01:44:05] Populate Memory Bank with initial project details (using README.md).
 

--- a/ui_interface.h
+++ b/ui_interface.h
@@ -26,6 +26,8 @@ public:
     // Performs any necessary cleanup for the UI.                                                                                                                        
     virtual void shutdown() = 0;                                                                                                                                         
                                                                                                                                                                          
+// Returns true if the UI is a graphical interface, false otherwise.
+    virtual bool isGuiMode() const = 0;
     // Virtual destructor to ensure proper cleanup of derived classes.                                                                                                   
     virtual ~UserInterface() = default;                                                                                                                                  
 };                                          


### PR DESCRIPTION
This PR implements the fix for issue #17 as discussed. It adds an `isGuiMode()` check to the `UserInterface` and modifies `ChatClient` to conditionally display the "(Ctrl+D to exit)" message only when not in GUI mode.