### PR TITLE
feat: Add white theme and toggle (fixes #18)

### DIFF
--- a/chat_client.cpp
+++ b/chat_client.cpp
@@ -30,8 +30,8 @@ std::string get_openrouter_api_key() {
 }
 
 // --- ChatClient Constructor ---
-ChatClient::ChatClient(UserInterface& ui_ref) :
-    db(),              // Initialize PersistenceManager
+ChatClient::ChatClient(UserInterface& ui_ref, PersistenceManager& db_ref) :
+    db(db_ref),        // Initialize PersistenceManager reference
     toolManager(),     // Initialize ToolManager
     ui(ui_ref)         // Initialize the UI reference
 {

--- a/chat_client.h
+++ b/chat_client.h
@@ -15,7 +15,7 @@ class ChatClient;
 // Now define ChatClient fully
 class ChatClient {
 private:
-    PersistenceManager db;
+    PersistenceManager& db; // Changed to reference
     ToolManager toolManager;
     UserInterface& ui; // Add reference to the UI
     std::string api_base = "https://openrouter.ai/api/v1/chat/completions";
@@ -55,7 +55,7 @@ private:
 
 public:
     // Constructor now requires a UserInterface reference
-    explicit ChatClient(UserInterface& ui_ref);
+    explicit ChatClient(UserInterface& ui_ref, PersistenceManager& db_ref); // Added db_ref
 
     // Public method for making API calls (used by web_research tool)
     std::string makeApiCall(const std::vector<Message>& context, bool use_tools = false);

--- a/database.h
+++ b/database.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <optional> // Added for std::optional
 
 struct Message {
     std::string role;
@@ -27,6 +28,9 @@ public:
     void beginTransaction();
     void commitTransaction();
     void rollbackTransaction();
+// Settings management
+    void saveSetting(const std::string& key, const std::string& value);
+    std::optional<std::string> loadSetting(const std::string& key);
 
 private:
     // Forward declaration for the Pimpl (Pointer to Implementation) idiom

--- a/gui_interface/gui_interface.cpp
+++ b/gui_interface/gui_interface.cpp
@@ -109,8 +109,8 @@ void GuiInterface::initialize() {
     // }
 
 
-    // Setup Dear ImGui style
-    ImGui::StyleColorsDark();
+    // Setup Dear ImGui style - REMOVED HARDCODED STYLE (Issue #18)
+    // ImGui::StyleColorsDark(); // This is now handled by setTheme
     // ImGui::StyleColorsClassic(); // Alternative style
 
 
@@ -370,3 +370,37 @@ ImVec2 GuiInterface::getAndClearScrollOffsets() {
 bool GuiInterface::isGuiMode() const {
     return true;
 }
+
+// --- Theme Helper Functions (Issue #18) ---
+void applyDarkTheme() {
+    ImGui::StyleColorsDark();
+    // Optional: Add custom dark theme adjustments here
+}
+
+void applyWhiteTheme() {
+    ImGui::StyleColorsLight(); // Use ImGui's built-in light theme
+    // Optional: Define a fully custom white theme here if needed
+    // Example:
+    // ImGuiStyle& style = ImGui::GetStyle();
+    // style.Colors[ImGuiCol_WindowBg] = ImVec4(0.94f, 0.94f, 0.94f, 1.00f);
+    // style.Colors[ImGuiCol_Text] = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+    // ... other color adjustments ...
+}
+// --- End Theme Helper Functions ---
+
+// --- Theme Setting Method Implementation (Issue #18) ---
+void GuiInterface::setTheme(ThemeType theme) {
+    switch (theme) {
+        case ThemeType::DARK:
+            applyDarkTheme();
+            break;
+        case ThemeType::WHITE:
+            applyWhiteTheme();
+            break;
+        default:
+            // Handle potential unknown theme type, maybe default to dark
+            applyDarkTheme();
+            break;
+    }
+}
+// --- End Theme Setting Method Implementation ---

--- a/gui_interface/gui_interface.cpp
+++ b/gui_interface/gui_interface.cpp
@@ -373,18 +373,139 @@ bool GuiInterface::isGuiMode() const {
 
 // --- Theme Helper Functions (Issue #18) ---
 void applyDarkTheme() {
-    ImGui::StyleColorsDark();
-    // Optional: Add custom dark theme adjustments here
+    ImGuiStyle& style = ImGui::GetStyle();
+    ImVec4* colors = style.Colors;
+
+    // Custom Dark Theme Colors
+    colors[ImGuiCol_Text]                   = ImVec4(0.88f, 0.88f, 0.88f, 1.00f); // Light Grey Text
+    colors[ImGuiCol_TextDisabled]           = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
+    colors[ImGuiCol_WindowBg]               = ImVec4(0.12f, 0.12f, 0.12f, 1.00f); // Very Dark Grey
+    colors[ImGuiCol_ChildBg]                = ImVec4(0.15f, 0.15f, 0.15f, 1.00f); // Slightly Lighter Dark Grey
+    colors[ImGuiCol_PopupBg]                = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
+    colors[ImGuiCol_Border]                 = ImVec4(0.31f, 0.31f, 0.31f, 0.50f); // Dark Grey Border
+    colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_FrameBg]                = ImVec4(0.23f, 0.23f, 0.23f, 1.00f); // Darker Grey Frame
+    colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.29f, 0.29f, 0.29f, 1.00f);
+    colors[ImGuiCol_FrameBgActive]          = ImVec4(0.35f, 0.35f, 0.35f, 1.00f);
+    colors[ImGuiCol_TitleBg]                = ImVec4(0.10f, 0.10f, 0.10f, 1.00f);
+    colors[ImGuiCol_TitleBgActive]          = ImVec4(0.00f, 0.48f, 0.80f, 1.00f); // Blue Accent Title Active
+    colors[ImGuiCol_TitleBgCollapsed]       = ImVec4(0.00f, 0.00f, 0.00f, 0.51f);
+    colors[ImGuiCol_MenuBarBg]              = ImVec4(0.14f, 0.14f, 0.14f, 1.00f);
+    colors[ImGuiCol_ScrollbarBg]            = ImVec4(0.02f, 0.02f, 0.02f, 0.53f);
+    colors[ImGuiCol_ScrollbarGrab]          = ImVec4(0.31f, 0.31f, 0.31f, 1.00f);
+    colors[ImGuiCol_ScrollbarGrabHovered]   = ImVec4(0.41f, 0.41f, 0.41f, 1.00f);
+    colors[ImGuiCol_ScrollbarGrabActive]    = ImVec4(0.51f, 0.51f, 0.51f, 1.00f);
+    colors[ImGuiCol_CheckMark]              = ImVec4(0.00f, 0.90f, 0.46f, 1.00f); // Green Accent Checkmark
+    colors[ImGuiCol_SliderGrab]             = ImVec4(0.43f, 0.43f, 0.43f, 1.00f); // Medium Grey Slider
+    colors[ImGuiCol_SliderGrabActive]       = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
+    colors[ImGuiCol_Button]                 = ImVec4(0.27f, 0.27f, 0.27f, 1.00f); // Medium Dark Grey Button
+    colors[ImGuiCol_ButtonHovered]          = ImVec4(0.31f, 0.31f, 0.31f, 1.00f);
+    colors[ImGuiCol_ButtonActive]           = ImVec4(0.36f, 0.36f, 0.36f, 1.00f);
+    colors[ImGuiCol_Header]                 = ImVec4(0.20f, 0.20f, 0.20f, 1.00f); // Dark Grey Header
+    colors[ImGuiCol_HeaderHovered]          = ImVec4(0.25f, 0.25f, 0.25f, 1.00f);
+    colors[ImGuiCol_HeaderActive]           = ImVec4(0.30f, 0.30f, 0.30f, 1.00f);
+    colors[ImGuiCol_Separator]              = colors[ImGuiCol_Border];
+    colors[ImGuiCol_SeparatorHovered]       = ImVec4(0.41f, 0.42f, 0.44f, 1.00f);
+    colors[ImGuiCol_SeparatorActive]        = ImVec4(0.51f, 0.53f, 0.55f, 1.00f);
+    colors[ImGuiCol_ResizeGrip]             = ImVec4(0.31f, 0.31f, 0.31f, 0.20f);
+    colors[ImGuiCol_ResizeGripHovered]      = ImVec4(0.41f, 0.41f, 0.41f, 0.67f);
+    colors[ImGuiCol_ResizeGripActive]       = ImVec4(0.51f, 0.51f, 0.51f, 0.95f);
+    colors[ImGuiCol_Tab]                    = ImVec4(0.18f, 0.18f, 0.18f, 0.86f);
+    colors[ImGuiCol_TabHovered]             = ImVec4(0.26f, 0.26f, 0.26f, 0.80f);
+    colors[ImGuiCol_TabActive]              = ImVec4(0.20f, 0.20f, 0.20f, 1.00f);
+    colors[ImGuiCol_TabUnfocused]           = ImVec4(0.15f, 0.15f, 0.15f, 0.97f);
+    colors[ImGuiCol_TabUnfocusedActive]     = ImVec4(0.14f, 0.14f, 0.14f, 1.00f);
+    colors[ImGuiCol_PlotLines]              = ImVec4(0.61f, 0.61f, 0.61f, 1.00f);
+    colors[ImGuiCol_PlotLinesHovered]       = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+    colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+    colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.19f, 0.19f, 0.20f, 1.00f);
+    colors[ImGuiCol_TableBorderStrong]      = ImVec4(0.31f, 0.31f, 0.35f, 1.00f);
+    colors[ImGuiCol_TableBorderLight]       = ImVec4(0.23f, 0.23f, 0.25f, 1.00f);
+    colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_TableRowBgAlt]          = ImVec4(1.00f, 1.00f, 1.00f, 0.06f);
+    colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+    colors[ImGuiCol_DragDropTarget]         = ImVec4(1.00f, 1.00f, 0.00f, 0.90f);
+    colors[ImGuiCol_NavHighlight]           = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+    colors[ImGuiCol_NavWindowingHighlight]  = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
+    colors[ImGuiCol_NavWindowingDimBg]      = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
+    colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
+
+    // Style adjustments
+    style.WindowRounding = 4.0f;
+    style.FrameRounding = 4.0f;
+    style.GrabRounding = 4.0f;
+    style.PopupRounding = 4.0f;
+    style.ScrollbarRounding = 4.0f;
+    style.TabRounding = 4.0f;
 }
 
 void applyWhiteTheme() {
-    ImGui::StyleColorsLight(); // Use ImGui's built-in light theme
-    // Optional: Define a fully custom white theme here if needed
-    // Example:
-    // ImGuiStyle& style = ImGui::GetStyle();
-    // style.Colors[ImGuiCol_WindowBg] = ImVec4(0.94f, 0.94f, 0.94f, 1.00f);
-    // style.Colors[ImGuiCol_Text] = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
-    // ... other color adjustments ...
+    ImGuiStyle& style = ImGui::GetStyle();
+    ImVec4* colors = style.Colors;
+
+    // Custom White Theme Colors
+    colors[ImGuiCol_Text]                   = ImVec4(0.12f, 0.12f, 0.12f, 1.00f); // Very Dark Grey Text
+    colors[ImGuiCol_TextDisabled]           = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
+    colors[ImGuiCol_WindowBg]               = ImVec4(0.96f, 0.96f, 0.96f, 1.00f); // Very Light Grey
+    colors[ImGuiCol_ChildBg]                = ImVec4(1.00f, 1.00f, 1.00f, 1.00f); // White
+    colors[ImGuiCol_PopupBg]                = ImVec4(1.00f, 1.00f, 1.00f, 0.98f);
+    colors[ImGuiCol_Border]                 = ImVec4(0.74f, 0.74f, 0.74f, 0.50f); // Grey Border
+    colors[ImGuiCol_BorderShadow]           = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_FrameBg]                = ImVec4(0.91f, 0.91f, 0.91f, 1.00f); // Slightly Darker Light Grey Frame
+    colors[ImGuiCol_FrameBgHovered]         = ImVec4(0.85f, 0.85f, 0.85f, 1.00f);
+    colors[ImGuiCol_FrameBgActive]          = ImVec4(0.78f, 0.78f, 0.78f, 1.00f);
+    colors[ImGuiCol_TitleBg]                = ImVec4(0.90f, 0.90f, 0.90f, 1.00f);
+    colors[ImGuiCol_TitleBgActive]          = ImVec4(0.75f, 0.75f, 0.75f, 1.00f); // Medium Grey Title Active
+    colors[ImGuiCol_TitleBgCollapsed]       = ImVec4(1.00f, 1.00f, 1.00f, 0.51f);
+    colors[ImGuiCol_MenuBarBg]              = ImVec4(0.86f, 0.86f, 0.86f, 1.00f);
+    colors[ImGuiCol_ScrollbarBg]            = ImVec4(0.98f, 0.98f, 0.98f, 0.53f);
+    colors[ImGuiCol_ScrollbarGrab]          = ImVec4(0.69f, 0.69f, 0.69f, 0.80f);
+    colors[ImGuiCol_ScrollbarGrabHovered]   = ImVec4(0.49f, 0.49f, 0.49f, 0.80f);
+    colors[ImGuiCol_ScrollbarGrabActive]    = ImVec4(0.39f, 0.39f, 0.39f, 0.80f);
+    colors[ImGuiCol_CheckMark]              = ImVec4(0.20f, 0.20f, 0.20f, 1.00f); // Dark Grey Checkmark
+    colors[ImGuiCol_SliderGrab]             = ImVec4(0.40f, 0.40f, 0.40f, 1.00f); // Medium Dark Grey Slider
+    colors[ImGuiCol_SliderGrabActive]       = ImVec4(0.30f, 0.30f, 0.30f, 1.00f);
+    colors[ImGuiCol_Button]                 = ImVec4(0.86f, 0.86f, 0.86f, 1.00f); // Lighter Grey Button
+    colors[ImGuiCol_ButtonHovered]          = ImVec4(0.78f, 0.78f, 0.78f, 1.00f);
+    colors[ImGuiCol_ButtonActive]           = ImVec4(0.70f, 0.70f, 0.70f, 1.00f);
+    colors[ImGuiCol_Header]                 = ImVec4(0.88f, 0.88f, 0.88f, 1.00f); // Light Grey Header
+    colors[ImGuiCol_HeaderHovered]          = ImVec4(0.82f, 0.82f, 0.82f, 1.00f);
+    colors[ImGuiCol_HeaderActive]           = ImVec4(0.75f, 0.75f, 0.75f, 1.00f);
+    colors[ImGuiCol_Separator]              = colors[ImGuiCol_Border];
+    colors[ImGuiCol_SeparatorHovered]       = ImVec4(0.60f, 0.60f, 0.70f, 1.00f);
+    colors[ImGuiCol_SeparatorActive]        = ImVec4(0.70f, 0.70f, 0.90f, 1.00f);
+    colors[ImGuiCol_ResizeGrip]             = ImVec4(0.80f, 0.80f, 0.80f, 0.56f);
+    colors[ImGuiCol_ResizeGripHovered]      = ImVec4(0.70f, 0.70f, 0.70f, 0.78f);
+    colors[ImGuiCol_ResizeGripActive]       = ImVec4(0.60f, 0.60f, 0.60f, 0.95f);
+    colors[ImGuiCol_Tab]                    = ImVec4(0.76f, 0.76f, 0.76f, 0.86f);
+    colors[ImGuiCol_TabHovered]             = ImVec4(0.84f, 0.84f, 0.84f, 0.80f);
+    colors[ImGuiCol_TabActive]              = ImVec4(0.88f, 0.88f, 0.88f, 1.00f);
+    colors[ImGuiCol_TabUnfocused]           = ImVec4(0.92f, 0.92f, 0.92f, 0.97f);
+    colors[ImGuiCol_TabUnfocusedActive]     = ImVec4(0.94f, 0.94f, 0.94f, 1.00f);
+    colors[ImGuiCol_PlotLines]              = ImVec4(0.40f, 0.40f, 0.40f, 1.00f);
+    colors[ImGuiCol_PlotLinesHovered]       = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+    colors[ImGuiCol_PlotHistogram]          = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+    colors[ImGuiCol_PlotHistogramHovered]   = ImVec4(1.00f, 0.45f, 0.00f, 1.00f);
+    colors[ImGuiCol_TableHeaderBg]          = ImVec4(0.78f, 0.78f, 0.78f, 1.00f);
+    colors[ImGuiCol_TableBorderStrong]      = ImVec4(0.57f, 0.57f, 0.64f, 1.00f);
+    colors[ImGuiCol_TableBorderLight]       = ImVec4(0.68f, 0.68f, 0.74f, 1.00f);
+    colors[ImGuiCol_TableRowBg]             = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+    colors[ImGuiCol_TableRowBgAlt]          = ImVec4(0.30f, 0.30f, 0.30f, 0.09f);
+    colors[ImGuiCol_TextSelectedBg]         = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+    colors[ImGuiCol_DragDropTarget]         = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+    colors[ImGuiCol_NavHighlight]           = colors[ImGuiCol_HeaderHovered];
+    colors[ImGuiCol_NavWindowingHighlight]  = ImVec4(0.70f, 0.70f, 0.70f, 0.70f);
+    colors[ImGuiCol_NavWindowingDimBg]      = ImVec4(0.20f, 0.20f, 0.20f, 0.20f);
+    colors[ImGuiCol_ModalWindowDimBg]       = ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
+
+    // Style adjustments
+    style.WindowRounding = 4.0f;
+    style.FrameRounding = 4.0f;
+    style.GrabRounding = 4.0f;
+    style.PopupRounding = 4.0f;
+    style.ScrollbarRounding = 4.0f;
+    style.TabRounding = 4.0f;
 }
 // --- End Theme Helper Functions ---
 

--- a/gui_interface/gui_interface.h
+++ b/gui_interface/gui_interface.h
@@ -28,7 +28,7 @@ struct HistoryMessage {
 // --- End Message History Structure ---
 
 // --- Theme Type Enum (Issue #18) ---
-enum ThemeType {
+enum class ThemeType {
     DARK,
     WHITE
 };

--- a/gui_interface/gui_interface.h
+++ b/gui_interface/gui_interface.h
@@ -26,6 +26,14 @@ struct HistoryMessage {
     std::string content;
 };
 // --- End Message History Structure ---
+
+// --- Theme Type Enum (Issue #18) ---
+enum ThemeType {
+    DARK,
+    WHITE
+};
+// --- End Theme Type Enum ---
+
 // Forward declaration for GLFW window handle
 struct GLFWwindow;
 
@@ -46,10 +54,14 @@ public:
     virtual void displayStatus(const std::string& status) override;
     virtual void initialize() override;
     virtual void shutdown() override;
-virtual bool isGuiMode() const override;
+    virtual bool isGuiMode() const override;
 
     // Public method to get the window handle (needed by main_gui.cpp)
     GLFWwindow* getWindow() const;
+
+    // --- Theme Setting Method (Issue #18) ---
+    void setTheme(ThemeType theme);
+    // --- End Theme Setting Method ---
 
     // --- Thread-safe methods for communication (Stage 4) ---
     void requestShutdown(); // Called by GUI thread to signal shutdown

--- a/main_cli.cpp
+++ b/main_cli.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept> // For runtime_error
 #include "chat_client.h" // Include the ChatClient header
 #include "cli_interface.h" // Include the CLI UI implementation header
+#include "database.h"    // Include the PersistenceManager header
 #include <stop_token>      // Include for std::stop_token
 
 // Use std namespace explicitly to avoid potential conflicts
@@ -12,10 +13,11 @@ using std::string;
 
 int main() {
     CliInterface cli_ui; // Instantiate the CLI UI
+    PersistenceManager db_manager; // Instantiate the DB manager
     try {
         cli_ui.initialize(); // Initialize the UI
 
-        ChatClient client(cli_ui); // Inject the UI into the client
+        ChatClient client(cli_ui, db_manager); // Inject the UI and DB manager into the client
         // Pass a default (non-stoppable) stop_token as the CLI uses Ctrl+D for exit
         client.run(std::stop_token{});
 

--- a/main_gui.cpp
+++ b/main_gui.cpp
@@ -186,7 +186,7 @@ int main(int, char**) {
                // Use TextWrapped for automatic wrapping and default theme color
                // Selectable still works with TextWrapped content if needed for copy
                ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x); // Enable wrapping
-               if (ImGui::Selectable(display_text.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_SpanAvailWidth)) {
+               if (ImGui::Selectable(display_text.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick)) {
                    ImGui::SetClipboardText(display_text.c_str());
                }
                ImGui::PopTextWrapPos();

--- a/main_gui.cpp
+++ b/main_gui.cpp
@@ -264,7 +264,7 @@ int main(int, char**) {
         glViewport(0, 0, display_w, display_h); // Set OpenGL viewport
         // Get the current background color from the theme
         clear_color = ImGui::GetStyle().Colors[ImGuiCol_WindowBg];
-        glClearColor(clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w, clear_color.w);
+        glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
         glClear(GL_COLOR_BUFFER_BIT); // Clear the screen
 
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData()); // Render ImGui draw data


### PR DESCRIPTION
Closes #18. Implements a white theme and a toggle mechanism in the GUI settings, allowing users to switch between dark and light themes. Includes TODOs for future persistence implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for switching between Dark and White themes in the GUI via a new Settings section.
  - Users can now change the app's appearance using radio buttons in the Settings panel.

- **Improvements**
  - The output area now resizes dynamically to accommodate the expanded or collapsed Settings panel.
  - The interface adapts text and background colors to match the selected theme.
  - Message colors for user input and status messages update according to the selected theme.
  - Background color dynamically reflects the current theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->