### PR TITLE
Fix: Parse and store all model fields from API response (resolves #34)

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -473,8 +473,27 @@ void PersistenceManager::clearModelsTable() {
 }
 
 void PersistenceManager::insertOrUpdateModel(const ModelData& model) {
-    // Using only id and name as per current ModelData definition
-    const char* sql = "INSERT INTO models (id, name) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET name=excluded.name;";
+    const char* sql = R"(
+INSERT INTO models (
+    id, name, description, context_length, pricing_prompt, pricing_completion,
+    architecture_input_modalities, architecture_output_modalities, architecture_tokenizer,
+    top_provider_is_moderated, per_request_limits, supported_parameters, created_at_api
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    name=excluded.name,
+    description=excluded.description,
+    context_length=excluded.context_length,
+    pricing_prompt=excluded.pricing_prompt,
+    pricing_completion=excluded.pricing_completion,
+    architecture_input_modalities=excluded.architecture_input_modalities,
+    architecture_output_modalities=excluded.architecture_output_modalities,
+    architecture_tokenizer=excluded.architecture_tokenizer,
+    top_provider_is_moderated=excluded.top_provider_is_moderated,
+    per_request_limits=excluded.per_request_limits,
+    supported_parameters=excluded.supported_parameters,
+    created_at_api=excluded.created_at_api,
+    last_updated_db=CURRENT_TIMESTAMP
+);)";
     sqlite3_stmt* stmt = nullptr;
 
     if (sqlite3_prepare_v2(impl->db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
@@ -484,8 +503,17 @@ void PersistenceManager::insertOrUpdateModel(const ModelData& model) {
 
     sqlite3_bind_text(stmt, 1, model.id.c_str(), -1, SQLITE_STATIC);
     sqlite3_bind_text(stmt, 2, model.name.c_str(), -1, SQLITE_STATIC);
-    // If ModelData is expanded, bind other parameters here. E.g.:
-    // sqlite3_bind_int(stmt, 3, model.context_length);
+    sqlite3_bind_text(stmt, 3, model.description.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_int(stmt, 4, model.context_length);
+    sqlite3_bind_text(stmt, 5, model.pricing_prompt.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 6, model.pricing_completion.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 7, model.architecture_input_modalities.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 8, model.architecture_output_modalities.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 9, model.architecture_tokenizer.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_int(stmt, 10, model.top_provider_is_moderated ? 1 : 0); // Store bool as 0 or 1
+    sqlite3_bind_text(stmt, 11, model.per_request_limits.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 12, model.supported_parameters.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_int64(stmt, 13, model.created_at_api); // Use int64 for long long
 
     if (sqlite3_step(stmt) != SQLITE_DONE) {
         throw std::runtime_error("insertOrUpdateModel failed: " + std::string(sqlite3_errmsg(impl->db)));

--- a/database.cpp
+++ b/database.cpp
@@ -493,7 +493,7 @@ ON CONFLICT(id) DO UPDATE SET
     supported_parameters=excluded.supported_parameters,
     created_at_api=excluded.created_at_api,
     last_updated_db=CURRENT_TIMESTAMP
-);)";
+)";
     sqlite3_stmt* stmt = nullptr;
 
     if (sqlite3_prepare_v2(impl->db, sql, -1, &stmt, nullptr) != SQLITE_OK) {

--- a/database.cpp
+++ b/database.cpp
@@ -491,7 +491,7 @@ ON CONFLICT(id) DO UPDATE SET
     top_provider_is_moderated=excluded.top_provider_is_moderated,
     per_request_limits=excluded.per_request_limits,
     supported_parameters=excluded.supported_parameters,
-    created_at_api=excluded.created_at_api,
+    created_at_api=excluded.created_at_api
     last_updated_db=CURRENT_TIMESTAMP
 );)";
     sqlite3_stmt* stmt = nullptr;

--- a/database.cpp
+++ b/database.cpp
@@ -491,7 +491,7 @@ ON CONFLICT(id) DO UPDATE SET
     top_provider_is_moderated=excluded.top_provider_is_moderated,
     per_request_limits=excluded.per_request_limits,
     supported_parameters=excluded.supported_parameters,
-    created_at_api=excluded.created_at_api
+    created_at_api=excluded.created_at_api,
     last_updated_db=CURRENT_TIMESTAMP
 );)";
     sqlite3_stmt* stmt = nullptr;


### PR DESCRIPTION
This pull request resolves issue #34 by updating the application to parse and store all available fields for AI models from the API response.

Changes include:
- Updated API response parsing in `ChatClient::parseModelsFromAPIResponse` in [`chat_client.cpp`](chat_client.cpp:0).
- Modified database insertion/update logic in `PersistenceManager::insertOrUpdateModel` in [`database.cpp`](database.cpp:0).
- Adjusted database retrieval logic in `PersistenceManager::getAllModels` in [`database.cpp`](database.cpp:0).

These changes ensure that fields such as description, context length, pricing, architecture details, provider information, request limits, and supported parameters are correctly handled and persisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced model details are now available, including descriptions, context length, creation date, pricing, architecture, moderation status, request limits, and supported parameters.
- **Improvements**
  - Model information is now more comprehensive and up-to-date when viewed or stored, providing richer metadata for each model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->