### PR TITLE
feat: add session management with /new and /chats commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ add_library(llm_core STATIC
     database/message_repository.h
     database/model_repository.cpp
     database/model_repository.h
+    database/session_repository.cpp
+    database/session_repository.h
     # Utility modules
     filesystem_utils.cpp
     filesystem_utils.h

--- a/chat_client.h
+++ b/chat_client.h
@@ -69,6 +69,9 @@ public:
     // Model management delegation
     void setActiveModel(const std::string& model_id);
 
+    // Session management
+    void switchToSession(int session_id);
+
     // Public API call method (for tools)
     std::string makeApiCall(const std::vector<Message>& context, bool use_tools = true);
 };

--- a/command_handler.cpp
+++ b/command_handler.cpp
@@ -1,20 +1,27 @@
 #include "command_handler.h"
 #include "model_manager.h"
+#include "database/session_repository.h"
 #include <stdexcept>
+#include <sstream>
+#include <iomanip>
 
 CommandHandler::CommandHandler(UserInterface& ui_ref,
                                PersistenceManager& db_ref,
                                ModelManager& model_manager_ref)
-    : ui(ui_ref), db(db_ref), modelManager(model_manager_ref) {
+    : ui(ui_ref), db(db_ref), modelManager(model_manager_ref), sessionSwitchCallback(nullptr) {
+}
+
+void CommandHandler::setSessionSwitchCallback(std::function<void(int)> callback) {
+    sessionSwitchCallback = callback;
 }
 
 bool CommandHandler::handleCommand(const std::string& input) {
     // Parse command - get first token (up to first space)
     size_t space_pos = input.find(' ');
-    std::string command = (space_pos != std::string::npos) 
-        ? input.substr(0, space_pos) 
+    std::string command = (space_pos != std::string::npos)
+        ? input.substr(0, space_pos)
         : input;
-    
+
     // Route to appropriate handler
     if (command == "/models") {
         handleModelsCommand();
@@ -24,7 +31,7 @@ bool CommandHandler::handleCommand(const std::string& input) {
             ui.displayError("Usage: /model <model-id>. Use /models to see available models.");
             return true;
         }
-        
+
         // Extract and trim model ID
         std::string model_id = input.substr(space_pos + 1);
         size_t start = model_id.find_first_not_of(" \t\n\r");
@@ -33,24 +40,32 @@ bool CommandHandler::handleCommand(const std::string& input) {
             return true;
         }
         model_id = model_id.substr(start);
-        
+
         size_t end = model_id.find_last_not_of(" \t\n\r");
         if (end != std::string::npos) {
             model_id = model_id.substr(0, end + 1);
         }
-        
+
         if (model_id.empty()) {
             ui.displayError("Usage: /model <model-id>. Use /models to see available models.");
             return true;
         }
-        
+
         handleModelCommand(model_id);
+        return true;
+    } else if (command == "/new") {
+        handleNewCommand();
+        return true;
+    } else if (command == "/chats") {
+        handleChatsCommand();
         return true;
     } else {
         // Unknown command
         ui.displayOutput("\nUnknown command. Available commands:\n"
                         "  /models - List all available models\n"
-                        "  /model <model-id> - Change the active model\n", "");
+                        "  /model <model-id> - Change the active model\n"
+                        "  /new - Start a new chat session\n"
+                        "  /chats - List all chat sessions\n", "");
         return true;
     }
 }
@@ -110,5 +125,57 @@ void CommandHandler::handleModelCommand(const std::string& model_id) {
         modelManager.setActiveModel(model_id);
     } catch (const std::exception& e) {
         ui.displayError("Error changing model: " + std::string(e.what()));
+    }
+}
+
+void CommandHandler::handleNewCommand() {
+    try {
+        // Create a new session
+        int new_session_id = db.createSession("New Chat");
+
+        // Switch to the new session
+        if (sessionSwitchCallback) {
+            sessionSwitchCallback(new_session_id);
+        }
+
+        ui.displayOutput("\nStarted new chat session (ID: " + std::to_string(new_session_id) + ")\n", "");
+    } catch (const std::exception& e) {
+        ui.displayError("Error creating new session: " + std::string(e.what()));
+    }
+}
+
+void CommandHandler::handleChatsCommand() {
+    try {
+        std::vector<database::Session> sessions = db.getAllSessions();
+
+        if (sessions.empty()) {
+            ui.displayOutput("\nNo chat sessions found.\n", "");
+            return;
+        }
+
+        std::string output = "\nChat Sessions:\n\n";
+
+        int current_session = db.getCurrentSession();
+
+        for (const auto& session : sessions) {
+            // Mark current session with [*]
+            if (session.id == current_session) {
+                output += "  [*] ";
+            } else {
+                output += "      ";
+            }
+
+            // Format: ID: Title (X messages) - Last active: timestamp
+            output += "ID " + std::to_string(session.id) + ": " + session.title;
+            output += " (" + std::to_string(session.message_count) + " messages)";
+            output += " - Last active: " + session.last_message_at;
+            output += "\n";
+        }
+
+        output += "\nUse /new to start a new session.\n";
+        ui.displayOutput(output, "");
+
+    } catch (const std::exception& e) {
+        ui.displayError("Error listing sessions: " + std::string(e.what()));
     }
 }

--- a/command_handler.h
+++ b/command_handler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <functional>
 #include "database.h"
 #include "ui_interface.h"
 
@@ -13,6 +14,8 @@ class ModelManager;
  * CommandHandler processes slash commands:
  * - /models - List all available models
  * - /model <id> - Change the active model
+ * - /new - Start a new chat session
+ * - /chats - List all chat sessions
  * Provides centralized command parsing and execution
  */
 class CommandHandler {
@@ -20,16 +23,22 @@ public:
     explicit CommandHandler(UserInterface& ui_ref,
                            PersistenceManager& db_ref,
                            ModelManager& model_manager_ref);
-    
+
     // Handle a command input. Returns true if command was handled, false otherwise
     bool handleCommand(const std::string& input);
+
+    // Callback for session switching
+    void setSessionSwitchCallback(std::function<void(int)> callback);
 
 private:
     UserInterface& ui;
     PersistenceManager& db;
     ModelManager& modelManager;
-    
+    std::function<void(int)> sessionSwitchCallback;
+
     // Individual command handlers
     void handleModelsCommand();
     void handleModelCommand(const std::string& model_id_arg);
+    void handleNewCommand();
+    void handleChatsCommand();
 };

--- a/database.cpp
+++ b/database.cpp
@@ -2,6 +2,7 @@
 #include "database/database_core.h"
 #include "database/message_repository.h"
 #include "database/model_repository.h"
+#include "database/session_repository.h"
 #include <memory>
 #include <stdexcept>
 #include <optional>
@@ -22,13 +23,15 @@ struct PersistenceManager::Impl {
     database::DatabaseCore core;
     database::MessageRepository messages;
     database::ModelRepository models;
-    
-    Impl() 
+    database::SessionRepository sessions;
+
+    Impl()
         : core()
         , messages(core)
         , models(core)
+        , sessions(core)
     {}
-    
+
     // Settings management remains in Impl (simple operations)
     void saveSetting(const std::string& key, const std::string& value);
     std::optional<std::string> loadSetting(const std::string& key);
@@ -152,4 +155,37 @@ void PersistenceManager::saveSetting(const std::string& key, const std::string& 
 
 std::optional<std::string> PersistenceManager::loadSetting(const std::string& key) {
     return impl->loadSetting(key);
+}
+
+// Session operations - delegate to SessionRepository
+int PersistenceManager::createSession(const std::string& title) {
+    return impl->sessions.createSession(title);
+}
+
+std::vector<database::Session> PersistenceManager::getAllSessions() {
+    return impl->sessions.getAllSessions();
+}
+
+std::optional<database::Session> PersistenceManager::getSessionById(int session_id) {
+    return impl->sessions.getSessionById(session_id);
+}
+
+void PersistenceManager::updateSessionTitle(int session_id, const std::string& title) {
+    impl->sessions.updateSessionTitle(session_id, title);
+}
+
+void PersistenceManager::deleteSession(int session_id) {
+    impl->sessions.deleteSession(session_id);
+}
+
+int PersistenceManager::getOrCreateDefaultSession() {
+    return impl->sessions.getOrCreateDefaultSession();
+}
+
+void PersistenceManager::setCurrentSession(int session_id) {
+    impl->messages.setCurrentSession(session_id);
+}
+
+int PersistenceManager::getCurrentSession() const {
+    return impl->messages.getCurrentSession();
 }

--- a/database.h
+++ b/database.h
@@ -6,6 +6,11 @@
 #include "model_types.h"
 struct sqlite3;
 
+// Forward declaration for Session struct
+namespace database {
+    struct Session;
+}
+
 // Message struct represents a single message in the chat history.
 struct Message {
     std::string role;
@@ -45,6 +50,16 @@ public:
     // Settings management
     void saveSetting(const std::string& key, const std::string& value);
     std::optional<std::string> loadSetting(const std::string& key);
+
+    // Session management
+    int createSession(const std::string& title = "New Chat");
+    std::vector<database::Session> getAllSessions();
+    std::optional<database::Session> getSessionById(int session_id);
+    void updateSessionTitle(int session_id, const std::string& title);
+    void deleteSession(int session_id);
+    int getOrCreateDefaultSession();
+    void setCurrentSession(int session_id);
+    int getCurrentSession() const;
 
 private:
     // Forward declaration for the Pimpl idiom

--- a/database/message_repository.h
+++ b/database/message_repository.h
@@ -25,31 +25,43 @@ public:
      * @param core Reference to DatabaseCore for connection access
      */
     explicit MessageRepository(DatabaseCore& core);
-    
+
+    /**
+     * Set the current session ID for message operations
+     * @param session_id The session ID to use
+     */
+    void setCurrentSession(int session_id);
+
+    /**
+     * Get the current session ID
+     * @return The current session ID
+     */
+    int getCurrentSession() const;
+
     // Message insertion methods
-    
+
     /**
      * Insert a user message into the database
      * @param content The message content
      */
     void insertUserMessage(const std::string& content);
-    
+
     /**
      * Insert an assistant message into the database
      * @param content The message content
      * @param model_id The ID of the model that generated the response
      */
     void insertAssistantMessage(const std::string& content, const std::string& model_id);
-    
+
     /**
      * Insert a tool message into the database
      * @param content The tool response content (must be valid JSON)
      * @throws std::runtime_error if content is not valid tool message JSON
      */
     void insertToolMessage(const std::string& content);
-    
+
     // Message retrieval methods
-    
+
     /**
      * Get recent conversation context for API calls
      * @param max_pairs Maximum number of user-assistant message pairs to retrieve
@@ -78,7 +90,8 @@ public:
 
 private:
     DatabaseCore& core_;  // Reference to database core for connection access
-    
+    int current_session_id_;  // Current session ID for message operations
+
     /**
      * Internal helper to insert a message
      * @param msg The message to insert

--- a/database/session_repository.cpp
+++ b/database/session_repository.cpp
@@ -1,0 +1,132 @@
+#include "session_repository.h"
+#include <stdexcept>
+
+namespace database {
+
+SessionRepository::SessionRepository(DatabaseCore& core)
+    : core_(core) {
+}
+
+int SessionRepository::createSession(const std::string& title) {
+    const char* sql = "INSERT INTO sessions (title) VALUES (?)";
+
+    auto stmt = core_.prepareStatement(sql);
+    sqlite3_bind_text(stmt.get(), 1, title.c_str(), -1, SQLITE_TRANSIENT);
+
+    if (sqlite3_step(stmt.get()) != SQLITE_DONE) {
+        throw std::runtime_error("Failed to create session: " +
+                                std::string(sqlite3_errmsg(core_.getConnection())));
+    }
+
+    return static_cast<int>(sqlite3_last_insert_rowid(core_.getConnection()));
+}
+
+std::vector<Session> SessionRepository::getAllSessions() {
+    const char* sql = R"(
+        SELECT
+            s.id,
+            s.title,
+            s.created_at,
+            COALESCE(MAX(m.timestamp), s.created_at) as last_message_at,
+            COUNT(m.id) as message_count
+        FROM sessions s
+        LEFT JOIN messages m ON s.id = m.session_id
+        GROUP BY s.id
+        ORDER BY last_message_at DESC
+    )";
+
+    auto stmt = core_.prepareStatement(sql);
+
+    std::vector<Session> sessions;
+    while (sqlite3_step(stmt.get()) == SQLITE_ROW) {
+        Session session;
+        session.id = sqlite3_column_int(stmt.get(), 0);
+        session.title = reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 1));
+        session.created_at = reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 2));
+        session.last_message_at = reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 3));
+        session.message_count = sqlite3_column_int(stmt.get(), 4);
+        sessions.push_back(session);
+    }
+
+    return sessions;
+}
+
+std::optional<Session> SessionRepository::getSessionById(int session_id) {
+    const char* sql = R"(
+        SELECT
+            s.id,
+            s.title,
+            s.created_at,
+            COALESCE(MAX(m.timestamp), s.created_at) as last_message_at,
+            COUNT(m.id) as message_count
+        FROM sessions s
+        LEFT JOIN messages m ON s.id = m.session_id
+        WHERE s.id = ?
+        GROUP BY s.id
+    )";
+
+    auto stmt = core_.prepareStatement(sql);
+    sqlite3_bind_int(stmt.get(), 1, session_id);
+
+    if (sqlite3_step(stmt.get()) == SQLITE_ROW) {
+        Session session;
+        session.id = sqlite3_column_int(stmt.get(), 0);
+        session.title = reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 1));
+        session.created_at = reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 2));
+        session.last_message_at = reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 3));
+        session.message_count = sqlite3_column_int(stmt.get(), 4);
+        return session;
+    }
+
+    return std::nullopt;
+}
+
+void SessionRepository::updateSessionTitle(int session_id, const std::string& title) {
+    const char* sql = "UPDATE sessions SET title = ? WHERE id = ?";
+
+    auto stmt = core_.prepareStatement(sql);
+    sqlite3_bind_text(stmt.get(), 1, title.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt.get(), 2, session_id);
+
+    if (sqlite3_step(stmt.get()) != SQLITE_DONE) {
+        throw std::runtime_error("Failed to update session title: " +
+                                std::string(sqlite3_errmsg(core_.getConnection())));
+    }
+}
+
+void SessionRepository::deleteSession(int session_id) {
+    // Delete all messages in the session first
+    const char* delete_messages_sql = "DELETE FROM messages WHERE session_id = ?";
+    auto delete_messages_stmt = core_.prepareStatement(delete_messages_sql);
+    sqlite3_bind_int(delete_messages_stmt.get(), 1, session_id);
+
+    if (sqlite3_step(delete_messages_stmt.get()) != SQLITE_DONE) {
+        throw std::runtime_error("Failed to delete session messages: " +
+                                std::string(sqlite3_errmsg(core_.getConnection())));
+    }
+
+    // Then delete the session
+    const char* delete_session_sql = "DELETE FROM sessions WHERE id = ?";
+    auto delete_session_stmt = core_.prepareStatement(delete_session_sql);
+    sqlite3_bind_int(delete_session_stmt.get(), 1, session_id);
+
+    if (sqlite3_step(delete_session_stmt.get()) != SQLITE_DONE) {
+        throw std::runtime_error("Failed to delete session: " +
+                                std::string(sqlite3_errmsg(core_.getConnection())));
+    }
+}
+
+int SessionRepository::getOrCreateDefaultSession() {
+    // Try to get the most recent session
+    const char* get_sql = "SELECT id FROM sessions ORDER BY created_at DESC LIMIT 1";
+    auto stmt = core_.prepareStatement(get_sql);
+
+    if (sqlite3_step(stmt.get()) == SQLITE_ROW) {
+        return sqlite3_column_int(stmt.get(), 0);
+    }
+
+    // No sessions exist, create a default one
+    return createSession("Default Chat");
+}
+
+} // namespace database

--- a/database/session_repository.h
+++ b/database/session_repository.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "database_core.h"
+#include <string>
+#include <vector>
+#include <optional>
+
+namespace database {
+
+/**
+ * Session struct represents a chat session
+ */
+struct Session {
+    int id = 0;
+    std::string title;
+    std::string created_at;
+    std::string last_message_at;
+    int message_count = 0;
+};
+
+/**
+ * SessionRepository - Encapsulates all session-related database operations
+ *
+ * Responsibilities:
+ * - Session creation
+ * - Session retrieval and listing
+ * - Session title updates
+ * - Session deletion
+ */
+class SessionRepository {
+public:
+    /**
+     * Constructor
+     * @param core Reference to DatabaseCore for connection access
+     */
+    explicit SessionRepository(DatabaseCore& core);
+
+    /**
+     * Create a new session
+     * @param title Optional title for the session (default: "New Chat")
+     * @return The ID of the newly created session
+     */
+    int createSession(const std::string& title = "New Chat");
+
+    /**
+     * Get all sessions ordered by most recent activity
+     * @return Vector of all sessions
+     */
+    std::vector<Session> getAllSessions();
+
+    /**
+     * Get a specific session by ID
+     * @param session_id The session ID
+     * @return Optional containing the session if found
+     */
+    std::optional<Session> getSessionById(int session_id);
+
+    /**
+     * Update session title
+     * @param session_id The session ID
+     * @param title The new title
+     */
+    void updateSessionTitle(int session_id, const std::string& title);
+
+    /**
+     * Delete a session and all its messages
+     * @param session_id The session ID
+     */
+    void deleteSession(int session_id);
+
+    /**
+     * Get the most recent session ID, or create one if none exists
+     * @return The session ID
+     */
+    int getOrCreateDefaultSession();
+
+private:
+    DatabaseCore& core_;
+};
+
+} // namespace database


### PR DESCRIPTION
Implement comprehensive session management to support multiple independent
chat conversations:

Database changes:
- Add sessions table to track individual chat sessions
- Add session_id foreign key to messages table
- Create SessionRepository for session CRUD operations
- Add migration to handle existing messages by creating default session

Session commands:
- /new - Create and switch to a new chat session
- /chats - List all sessions with message counts and last activity

Core changes:
- Update MessageRepository to filter messages by current session
- Add session tracking to PersistenceManager
- Update ChatClient to initialize and switch between sessions
- Add session callback mechanism in CommandHandler

Each session maintains its own isolated message history, allowing users
to organize conversations by topic without mixing contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-authored-by: Sculptor <sculptor@imbue.com>
